### PR TITLE
[SPARK-23724][SQL] Record delimiter for the json datasource reader

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/CreateJacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/CreateJacksonParser.scala
@@ -22,6 +22,7 @@ import java.io.{ByteArrayInputStream, InputStream, InputStreamReader}
 import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
 import org.apache.hadoop.io.Text
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.unsafe.types.UTF8String
 
 private[sql] object CreateJacksonParser extends Serializable {
@@ -59,5 +60,14 @@ private[sql] object CreateJacksonParser extends Serializable {
       case _ =>
         jsonFactory.createParser(is)
     }
+  }
+
+  def internalRow(
+    jsonFactory: JsonFactory,
+    row: InternalRow,
+    charset: Option[String] = None
+  ): JsonParser = {
+    val is = new ByteArrayInputStream(row.getBinary(0))
+    inputStream(jsonFactory, is, charset)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -91,8 +91,11 @@ private[sql] class JSONOptions(
    */
   val charset: Option[String] = parameters.get("charset")
 
-  // A separator of json records
-  val sep: Option[Array[Byte]] = parameters.get("sep").map(
+  /**
+   * A sequence of bytes between two consecutive json records. Supported formats:
+   * - sequence of bytes in hex format (starts from x): x0a 0d
+   */
+  val recordSeparator: Option[Array[Byte]] = parameters.get("recordSeparator").map(
     _.replaceAll("[^0-9A-Fa-f]", "")
      .sliding(2, 2)
      .toArray.map(Integer.parseInt(_, 16).toByte)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.json
 import java.util.{Locale, TimeZone}
 
 import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
-import org.apache.commons.codec.binary.Base64
 import org.apache.commons.lang3.time.FastDateFormat
 
 import org.apache.spark.internal.Logging

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -99,6 +99,10 @@ private[sql] class JSONOptions(
    *   Hex pairs can be separated by any chars different from 0-9,A-F,a-f
    * - '\' - reserved for a sequence of control chars like "\r\n"
    *         and unicode escape like "\u000D\u000A"
+   *
+   * Note: the option defines a delimiter for the json reader only, the json writer
+   * uses '\n' as the delimiter of output records (it is converted to sequence of
+   * bytes according to charset)
    */
   val recordDelimiter: Option[Array[Byte]] = parameters.get("recordDelimiter").collect {
     case hexs if hexs.startsWith("x") =>
@@ -118,5 +122,11 @@ private[sql] class JSONOptions(
     factory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
       allowBackslashEscapingAnyCharacter)
     factory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, allowUnquotedControlChars)
+  }
+
+  def getTextOptions: Map[String, String] = {
+    recordDelimiter.map{ bytes =>
+      "recordDelimiter" -> bytes.map("%02x".format(_)).mkString
+    }.toMap
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -95,7 +95,7 @@ private[sql] class JSONOptions(
    * A sequence of bytes between two consecutive json records. Supported formats:
    * - sequence of bytes in hex format (starts from x): x0a 0d
    */
-  val recordSeparator: Option[Array[Byte]] = parameters.get("recordSeparator").map(
+  val recordDelimiter: Option[Array[Byte]] = parameters.get("recordDelimiter").map(
     _.replaceAll("[^0-9A-Fa-f]", "")
      .sliding(2, 2)
      .toArray.map(Integer.parseInt(_, 16).toByte)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -98,13 +98,14 @@ private[sql] class JSONOptions(
    * - 'x' + sequence of bytes in hexadecimal format. For example: "x0a 0d".
    *   Hex pairs can be separated by any chars different from 0-9,A-F,a-f
    * - '\' - reserved for a sequence of control chars like "\r\n"
-   * - '/' - reserved for a sequence of visible chars like "/==="
+   *         and unicode escape like "\u000D\u000A"
    */
   val recordDelimiter: Option[Array[Byte]] = parameters.get("recordDelimiter").collect {
     case hexs if hexs.startsWith("x") =>
       hexs.replaceAll("[^0-9A-Fa-f]", "").sliding(2, 2).toArray
         .map(Integer.parseInt(_, 16).toByte)
-    case d => throw new NotImplementedError(d)
+    case delim => delim.getBytes(charset.getOrElse(
+      throw new IllegalArgumentException("Please, set the charset option for the delimiter")))
   }
 
   /** Sets config options on a Jackson [[JsonFactory]]. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -99,6 +99,8 @@ private[sql] class JSONOptions(
    *   Hex pairs can be separated by any chars different from 0-9,A-F,a-f
    * - '\' - reserved for a sequence of control chars like "\r\n"
    *         and unicode escape like "\u000D\u000A"
+   * - 'r' - specifies a regular expression
+   * - 'none' - json records are not divided by any delimiter
    *
    * Note: the option defines a delimiter for the json reader only, the json writer
    * uses '\n' as the delimiter of output records (it is converted to sequence of
@@ -108,6 +110,8 @@ private[sql] class JSONOptions(
     case hexs if hexs.startsWith("x") =>
       hexs.replaceAll("[^0-9A-Fa-f]", "").sliding(2, 2).toArray
         .map(Integer.parseInt(_, 16).toByte)
+    case reserved if reserved.startsWith("r") || reserved.startsWith("none") =>
+      throw new NotImplementedError(s"the $reserved selector has not supported yet")
     case delim => delim.getBytes(charset.getOrElse(
       throw new IllegalArgumentException("Please, set the charset option for the delimiter")))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -92,9 +92,12 @@ private[sql] class JSONOptions(
    */
   val charset: Option[String] = parameters.get("charset")
 
-  val delimiter: Option[Array[Byte]] = {
-    parameters.get("delimiter").map(Base64.decodeBase64(_))
-  }
+  // A separator of json records
+  val sep: Option[Array[Byte]] = parameters.get("sep").map(
+    _.replaceAll("[^0-9A-Fa-f]", "")
+     .sliding(2, 2)
+     .toArray.map(Integer.parseInt(_, 16).toByte)
+  )
 
   /** Sets config options on a Jackson [[JsonFactory]]. */
   def setJacksonOptions(factory: JsonFactory): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.json
 import java.util.{Locale, TimeZone}
 
 import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
+import org.apache.commons.codec.binary.Base64
 import org.apache.commons.lang3.time.FastDateFormat
 
 import org.apache.spark.internal.Logging
@@ -90,6 +91,10 @@ private[sql] class JSONOptions(
    * If charset is not specified (None), it will be detected automatically.
    */
   val charset: Option[String] = parameters.get("charset")
+
+  val delimiter: Option[Array[Byte]] = {
+    parameters.get("delimiter").map(Base64.decodeBase64(_))
+  }
 
   /** Sets config options on a Jackson [[JsonFactory]]. */
   def setJacksonOptions(factory: JsonFactory): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 class HadoopFileLinesReader(
     file: PartitionedFile,
     conf: Configuration,
-    lineSeparator: Option[Array[Byte]] = None
+    recordDelimiter: Option[Array[Byte]] = None
   ) extends Iterator[Text] with Closeable {
   private val iterator = {
     val fileSplit = new FileSplit(
@@ -45,8 +45,8 @@ class HadoopFileLinesReader(
       Array.empty)
     val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
     val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
-    val reader = lineSeparator match {
-      case Some(sep) => new LineRecordReader(sep)
+    val reader = recordDelimiter match {
+      case Some(delim) => new LineRecordReader(delim)
       case _ => new LineRecordReader()
     }
     reader.initialize(fileSplit, hadoopAttemptContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
@@ -32,7 +32,10 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
  * in that file.
  */
 class HadoopFileLinesReader(
-    file: PartitionedFile, conf: Configuration) extends Iterator[Text] with Closeable {
+    file: PartitionedFile,
+    conf: Configuration,
+    recordDelimiter: Option[Array[Byte]] = None
+  ) extends Iterator[Text] with Closeable {
   private val iterator = {
     val fileSplit = new FileSplit(
       new Path(new URI(file.filePath)),
@@ -42,7 +45,10 @@ class HadoopFileLinesReader(
       Array.empty)
     val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
     val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
-    val reader = new LineRecordReader()
+    val reader = recordDelimiter match {
+      case Some(delimiter) => new LineRecordReader(delimiter)
+      case _ => new LineRecordReader()
+    }
     reader.initialize(fileSplit, hadoopAttemptContext)
     new RecordReaderIterator(reader)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/HadoopFileLinesReader.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 class HadoopFileLinesReader(
     file: PartitionedFile,
     conf: Configuration,
-    recordDelimiter: Option[Array[Byte]] = None
+    lineSeparator: Option[Array[Byte]] = None
   ) extends Iterator[Text] with Closeable {
   private val iterator = {
     val fileSplit = new FileSplit(
@@ -45,8 +45,8 @@ class HadoopFileLinesReader(
       Array.empty)
     val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
     val hadoopAttemptContext = new TaskAttemptContextImpl(conf, attemptId)
-    val reader = recordDelimiter match {
-      case Some(delimiter) => new LineRecordReader(delimiter)
+    val reader = lineSeparator match {
+      case Some(sep) => new LineRecordReader(sep)
       case _ => new LineRecordReader()
     }
     reader.initialize(fileSplit, hadoopAttemptContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -120,7 +120,7 @@ object TextInputJsonDataSource extends JsonDataSource {
       file: PartitionedFile,
       parser: JacksonParser,
       schema: StructType): Iterator[InternalRow] = {
-    val linesReader = new HadoopFileLinesReader(file, conf,parser.options.sep)
+    val linesReader = new HadoopFileLinesReader(file, conf, parser.options.recordSeparator)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => linesReader.close()))
     val charset = parser.options.charset
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -120,7 +120,7 @@ object TextInputJsonDataSource extends JsonDataSource {
       file: PartitionedFile,
       parser: JacksonParser,
       schema: StructType): Iterator[InternalRow] = {
-    val linesReader = new HadoopFileLinesReader(file, conf, parser.options.recordSeparator)
+    val linesReader = new HadoopFileLinesReader(file, conf, parser.options.recordDelimiter)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => linesReader.close()))
     val charset = parser.options.charset
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -120,7 +120,7 @@ object TextInputJsonDataSource extends JsonDataSource {
       file: PartitionedFile,
       parser: JacksonParser,
       schema: StructType): Iterator[InternalRow] = {
-    val linesReader = new HadoopFileLinesReader(file, conf)
+    val linesReader = new HadoopFileLinesReader(file, conf, parser.options.delimiter)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => linesReader.close()))
     val charset = parser.options.charset
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonDataSource.scala
@@ -120,7 +120,7 @@ object TextInputJsonDataSource extends JsonDataSource {
       file: PartitionedFile,
       parser: JacksonParser,
       schema: StructType): Iterator[InternalRow] = {
-    val linesReader = new HadoopFileLinesReader(file, conf, parser.options.delimiter)
+    val linesReader = new HadoopFileLinesReader(file, conf,parser.options.sep)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => linesReader.close()))
     val charset = parser.options.charset
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
@@ -39,9 +39,13 @@ private[text] class TextOptions(@transient private val parameters: CaseInsensiti
    */
   val wholeText = parameters.getOrElse(WHOLETEXT, "false").toBoolean
 
+  val recordDelimiter: Option[Array[Byte]] = parameters.get(RECORDDELIMITER).map { hex =>
+    hex.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+  }
 }
 
 private[text] object TextOptions {
   val COMPRESSION = "compression"
   val WHOLETEXT = "wholetext"
+  val RECORDDELIMITER = "recordDelimiter"
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2069,12 +2069,11 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
   }
 
   test("json in UTF-16 with BOM") {
+    import java.util.Base64
     val fileName = "json-tests/utf16WithBOM.json"
     val schema = new StructType().add("firstName", StringType).add("lastName", StringType)
     val jsonDF = spark.read.schema(schema)
-      // The mode filters null rows produced because new line delimiter
-      // for UTF-8 is used by default.
-      .option("mode", "DROPMALFORMED")
+      .option("delimiter", Base64.getEncoder.encodeToString(Array(0xd.toByte, 0, 0xa.toByte, 0)))
       .json(testFile(fileName))
 
     checkAnswer(jsonDF, Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.json
 
-import java.io.{File, StringWriter}
+import java.io.{File, FileOutputStream, StringWriter}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.util.Locale
@@ -2213,8 +2213,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
   }
 
   def checkReadWrittenJson(charset: String, delimiter: String, runId: Int): Unit = {
-    test(s"checks Spark is able to read json written by Spark itself #{$runId}") {
-      case class Rec(f1: String, f2: Int)
+    test(s"checks Spark is able to read json written by Spark itself #${runId}") {
       withTempPath { path =>
         val ds = spark.createDataset(Seq(
           ("a", 1), ("b", 2), ("c", 3))
@@ -2242,4 +2241,46 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     ("\u000a", "UTF-32BE"),
     ("x0a 00 00 00", "UTF-32LE")
   ).zipWithIndex.foreach{case ((d, c), i) => checkReadWrittenJson(c, d, i)}
+
+  def checkReadJson(charset: String, delimiter: String, runId: Int): Unit = {
+    test(s"checks reading json in ${charset} #${runId}") {
+      val delimInBytes = {
+        if (delimiter.startsWith("x")) {
+          delimiter.replaceAll("[^0-9A-Fa-f]", "")
+            .sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+        } else {
+          delimiter.getBytes(charset)
+        }
+      }
+      case class Rec(f1: String, f2: Int) {
+        def json = s"""{"f1":"${f1}", "f2":$f2}"""
+        def bytes = json.getBytes(charset)
+        def row = Row(f1, f2)
+      }
+      val schema = new StructType().add("f1", StringType).add("f2", IntegerType)
+      withTempPath { path =>
+        val records = List(Rec("a", 1), Rec("b", 2))
+        val data = records.map(_.bytes).reduce((a1, a2) => a1 ++ delimInBytes ++ a2)
+        val os = new FileOutputStream(path)
+        os.write(data)
+        os.close()
+        val savedDf = spark
+          .read
+          .schema(schema)
+          .option("charset", charset)
+          .option("recordDelimiter", delimiter)
+          .json(path.getCanonicalPath)
+        checkAnswer(savedDf, records.map(_.row))
+      }
+    }
+  }
+
+  List(
+    ("sep", "UTF-8"),
+    ("x00 0a 00 0d", "UTF-16BE"),
+    ("\r\n", "UTF-16LE"),
+    ("\u000d\u000a", "UTF-32BE"),
+    ("===", "UTF-32LE"),
+    ("куку", "CP1251")
+  ).zipWithIndex.foreach{case ((d, c), i) => checkReadJson(c, d, i)}
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2212,7 +2212,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     assert(causedBy.getMessage == charset)
   }
 
-  def readSparkJson(charset: String, delimiter: String, runId: Int): Unit = {
+  def checkReadWrittenJson(charset: String, delimiter: String, runId: Int): Unit = {
     test(s"checks Spark is able to read json written by Spark itself #{$runId}") {
       case class Rec(f1: String, f2: Int)
       withTempPath { path =>
@@ -2241,5 +2241,5 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     ("\n", "UTF-16LE"),
     ("\u000a", "UTF-32BE"),
     ("x0a 00 00 00", "UTF-32LE")
-  ).zipWithIndex.foreach{case ((d, c), i) => readSparkJson(c, d, i)}
+  ).zipWithIndex.foreach{case ((d, c), i) => checkReadWrittenJson(c, d, i)}
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2212,10 +2212,8 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     assert(causedBy.getMessage == charset)
   }
 
-  def readWrittenJson(delimiter: (String, Int)): Unit = {
-    val (recordDelimiter, index) = delimiter
-    test(s"read written json in UTF-16BE with delimiter $index") {
-      val charset = "UTF-16BE"
+  def readSparkJson(charset: String, delimiter: String, runId: Int): Unit = {
+    test(s"checks Spark is able to read json written by Spark itself #{$runId}") {
       case class Rec(f1: String, f2: Int)
       withTempPath { path =>
         val ds = spark.createDataset(Seq(
@@ -2229,7 +2227,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
           .read
           .schema(ds.schema)
           .option("charset", charset)
-          .option("recordDelimiter", recordDelimiter)
+          .option("recordDelimiter", delimiter)
           .json(path.getCanonicalPath)
 
         checkAnswer(savedDf.toDF(), ds.toDF())
@@ -2237,5 +2235,11 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     }
   }
 
-  List("x00 0a", "\n", "\u000a").zipWithIndex.foreach(readWrittenJson(_))
+  List(
+    ("\n", "UTF-8"),
+    ("x00 0a", "UTF-16BE"),
+    ("\n", "UTF-16LE"),
+    ("\u000a", "UTF-32BE"),
+    ("x0a 00 00 00", "UTF-32LE")
+  ).zipWithIndex.foreach{case ((d, c), i) => readSparkJson(c, d, i)}
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2293,7 +2293,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     ("\u000a\u000d", "UTF-32BE", true),
     ("===", "UTF-32LE", false),
     ("$^+", "UTF-32LE", true),
-    ("куку", "CP1251", false),
-    ("куку", "CP1251", true)
+    ("xEA.F3.EA.F3", "CP1251", false),
+    ("xEA.F3.EA.F3", "CP1251", true)
   ).zipWithIndex.foreach{case ((d, c, s), i) => checkReadJson(c, d, s, i)}
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2212,25 +2212,30 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     assert(causedBy.getMessage == charset)
   }
 
-  test("read written json in UTF-16") {
-    val charset = "UTF-16"
-    case class Rec(f1: String, f2: Int)
-    withTempPath { path =>
-      val ds = spark.createDataset(Seq(
-        ("a", 1), ("b", 2), ("c", 3))
-      ).repartition(1)
-      ds.write
-        .option("charset", charset)
-        .format("json").mode("overwrite")
-        .save(path.getCanonicalPath)
-      val savedDf = spark
-        .read
-        .schema(ds.schema)
-        .option("charset", charset)
-        .option("recordDelimiter", "x00 0a")
-        .json(path.getCanonicalPath)
+  def readWrittenJson(delimiter: (String, Int)): Unit = {
+    val (recordDelimiter, index) = delimiter
+    test(s"read written json in UTF-16BE with delimiter $index") {
+      val charset = "UTF-16BE"
+      case class Rec(f1: String, f2: Int)
+      withTempPath { path =>
+        val ds = spark.createDataset(Seq(
+          ("a", 1), ("b", 2), ("c", 3))
+        ).repartition(1)
+        ds.write
+          .option("charset", charset)
+          .format("json").mode("overwrite")
+          .save(path.getCanonicalPath)
+        val savedDf = spark
+          .read
+          .schema(ds.schema)
+          .option("charset", charset)
+          .option("recordDelimiter", recordDelimiter)
+          .json(path.getCanonicalPath)
 
-      checkAnswer(savedDf.toDF(), ds.toDF())
+        checkAnswer(savedDf.toDF(), ds.toDF())
+      }
     }
   }
+
+  List("x00 0a", "\n", "\u000a").zipWithIndex.foreach(readWrittenJson(_))
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2242,7 +2242,12 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     ("x0a 00 00 00", "UTF-32LE")
   ).zipWithIndex.foreach{case ((d, c), i) => checkReadWrittenJson(c, d, i)}
 
-  def checkReadJson(charset: String, delimiter: String, runId: Int): Unit = {
+  def checkReadJson(
+    charset: String,
+    delimiter: String,
+    inferSchema: Boolean,
+    runId: Int
+  ): Unit = {
     test(s"checks reading json in ${charset} #${runId}") {
       val delimInBytes = {
         if (delimiter.startsWith("x")) {
@@ -2264,9 +2269,12 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         val os = new FileOutputStream(path)
         os.write(data)
         os.close()
-        val savedDf = spark
-          .read
-          .schema(schema)
+        val reader = if (inferSchema) {
+          spark.read
+        } else {
+          spark.read.schema(schema)
+        }
+        val savedDf = reader
           .option("charset", charset)
           .option("recordDelimiter", delimiter)
           .json(path.getCanonicalPath)
@@ -2276,11 +2284,16 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
   }
 
   List(
-    ("sep", "UTF-8"),
-    ("x00 0a 00 0d", "UTF-16BE"),
-    ("\r\n", "UTF-16LE"),
-    ("\u000d\u000a", "UTF-32BE"),
-    ("===", "UTF-32LE"),
-    ("куку", "CP1251")
-  ).zipWithIndex.foreach{case ((d, c), i) => checkReadJson(c, d, i)}
+    ("sep", "UTF-8", false),
+    ("x00 0a 00 0d", "UTF-16BE", false),
+    ("x00 0a 00 0d", "UTF-16BE", true),
+    ("\r\n", "UTF-16LE", false),
+    ("\r\n", "UTF-16LE", true),
+    ("\u000d\u000a", "UTF-32BE", false),
+    ("\u000a\u000d", "UTF-32BE", true),
+    ("===", "UTF-32LE", false),
+    ("$^+", "UTF-32LE", true),
+    ("куку", "CP1251", false),
+    ("куку", "CP1251", true)
+  ).zipWithIndex.foreach{case ((d, c, s), i) => checkReadJson(c, d, s, i)}
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2069,11 +2069,10 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
   }
 
   test("json in UTF-16 with BOM") {
-    import java.util.Base64
     val fileName = "json-tests/utf16WithBOM.json"
     val schema = new StructType().add("firstName", StringType).add("lastName", StringType)
     val jsonDF = spark.read.schema(schema)
-      .option("delimiter", Base64.getEncoder.encodeToString(Array(0xd.toByte, 0, 0xa.toByte, 0)))
+      .option("sep", "0d 00 0a 00")
       .json(testFile(fileName))
 
     checkAnswer(jsonDF, Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2218,7 +2218,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     withTempPath { path =>
       val ds = spark.createDataset(Seq(
         ("a", 1), ("b", 2), ("c", 3))
-      ).repartition(2)
+      ).repartition(1)
       ds.write
         .option("charset", charset)
         .format("json").mode("overwrite")
@@ -2227,9 +2227,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         .read
         .schema(ds.schema)
         .option("charset", charset)
-        // Wrong (nulls) rows are produced because new line delimiter
-        // for UTF-8 is used by default.
-        .option("mode", "DROPMALFORMED")
+        .option("recordSeparator", "x00 0a")
         .json(path.getCanonicalPath)
 
       checkAnswer(savedDf.toDF(), ds.toDF())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2072,7 +2072,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     val fileName = "json-tests/utf16WithBOM.json"
     val schema = new StructType().add("firstName", StringType).add("lastName", StringType)
     val jsonDF = spark.read.schema(schema)
-      .option("sep", "0d 00 0a 00")
+      .option("recordSeparator", "x0d 00 0a 00")
       .json(testFile(fileName))
 
     checkAnswer(jsonDF, Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2072,7 +2072,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
     val fileName = "json-tests/utf16WithBOM.json"
     val schema = new StructType().add("firstName", StringType).add("lastName", StringType)
     val jsonDF = spark.read.schema(schema)
-      .option("recordSeparator", "x0d 00 0a 00")
+      .option("recordDelimiter", "x0d 00 0a 00")
       .json(testFile(fileName))
 
     checkAnswer(jsonDF, Seq(
@@ -2227,7 +2227,7 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
         .read
         .schema(ds.schema)
         .option("charset", charset)
-        .option("recordSeparator", "x00 0a")
+        .option("recordDelimiter", "x00 0a")
         .json(path.getCanonicalPath)
 
       checkAnswer(savedDf.toDF(), ds.toDF())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, TextInputJsonDataSource uses HadoopFileLinesReader to split json file to separate lines. The former one splits json lines by LineRecordReader without providing recordDelimiter. As a consequence of that, the hadoop library reads lines terminated by one of CR, LF, or CRLF. In the case if input charset is different from UTF-8, JSON reader produces many nulls rows. The changes allow to specify the line separator instead of using the auto detection method of hadoop library. If the separator is not specified, the line separation method of Hadoop is used by default.

The options together with the charset option will allow users to read json files in per-line mode in any charset and get results without garbage like null rows.

## How was this patch tested?

I specified the separator and removed the DROPMALFORMED mode from existing tests. Besides of that I added a few tests for different record delimiters.
