### PR TITLE
Making JSON datasource respectful to spark.sql.caseSensitive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -524,6 +524,8 @@ case class JsonToStructs(
   // can generate incorrect files if values are missing in columns declared as non-nullable.
   val nullableSchema = if (forceNullableSchema) schema.asNullable else schema
 
+  val caseSensitive = SQLConf.get.getConf(SQLConf.CASE_SENSITIVE)
+
   override def nullable: Boolean = true
 
   // Used in `FunctionRegistry`
@@ -567,7 +569,8 @@ case class JsonToStructs(
   lazy val parser =
     new JacksonParser(
       rowSchema,
-      new JSONOptions(options + ("mode" -> FailFastMode.name), timeZoneId.get))
+      new JSONOptions(options + ("mode" -> FailFastMode.name), timeZoneId.get),
+      caseSensitive)
 
   override def dataType: DataType = nullableSchema
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -419,9 +419,10 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       extraOptions.toMap,
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
+    val caseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
 
     val schema = userSpecifiedSchema.getOrElse {
-      TextInputJsonDataSource.inferFromDataset(jsonDataset, parsedOptions)
+      TextInputJsonDataSource.inferFromDataset(jsonDataset, parsedOptions, caseSensitive)
     }
 
     verifyColumnNameOfCorruptRecord(schema, parsedOptions.columnNameOfCorruptRecord)
@@ -430,7 +431,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
 
     val createParser = CreateJacksonParser.string _
     val parsed = jsonDataset.rdd.mapPartitions { iter =>
-      val rawParser = new JacksonParser(actualSchema, parsedOptions)
+      val rawParser = new JacksonParser(actualSchema, parsedOptions, caseSensitive)
       val parser = new FailureSafeParser[String](
         input => rawParser.parse(input, createParser, UTF8String.fromString),
         parsedOptions.parseMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JsonFileFormat.scala
@@ -126,9 +126,10 @@ class JsonFileFormat extends TextBasedFileFormat with DataSourceRegister {
         "df.filter($\"_corrupt_record\".isNotNull).count()."
       )
     }
+    val caseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
 
     (file: PartitionedFile) => {
-      val parser = new JacksonParser(actualSchema, parsedOptions)
+      val parser = new JacksonParser(actualSchema, parsedOptions, caseSensitive)
       JsonDataSource(parsedOptions).readFile(
         broadcastedHadoopConf.value.value,
         file,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, JSON datasource is case sensitive and not respectful to the `caseSensitive` parameter. It causes the problem of reading json records with fields in different cases. For example, the following json file - *test.json* contains fields in different cases:

```
{"field": "a"}
{"Field": "b"}
{"FIELD": "c"}
```
Creating the table *test* by using the json file:
```
CREATE TABLE test USING json LOCATION test.json
```
Querying the table:
```
SELECT field FROM test
```
returns only the first row:
```
+-----+
|field|
+-----+
|    a|
| null|
| null|
+-----+
```

After applying the proposed changes:
```
+-----+
|field|
+-----+
|    a|
|    b|
|    c|
+-----+
```
## How was this patch tested?
