### PR TITLE
[SQL] Allow to specify size of null

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2222,18 +2222,21 @@ def to_json(col, options={}):
 
 
 @since(1.5)
-def size(col):
+def size(col, sizeOfNull=-1):
     """
     Collection function: returns the length of the array or map stored in the column.
 
     :param col: name of column or expression
+    :param sizeOfNull: size of null input
 
-    >>> df = spark.createDataFrame([([1, 2, 3],),([1],),([],)], ['data'])
+    >>> df = spark.createDataFrame([([1, 2, 3],),([1],),([],),(None,)], ['data'])
     >>> df.select(size(df.data)).collect()
-    [Row(size(data)=3), Row(size(data)=1), Row(size(data)=0)]
+    [Row(size(data)=3), Row(size(data)=1), Row(size(data)=0), Row(size(data)=-1)]
+    >>> df.select(size(df.data, 0)).collect()
+    [Row(size(data)=3), Row(size(data)=1), Row(size(data)=0), Row(size(data)=0)]
     """
     sc = SparkContext._active_spark_context
-    return Column(sc._jvm.functions.size(_to_java_column(col)))
+    return Column(sc._jvm.functions.size(_to_java_column(col), sizeOfNull))
 
 
 @since(2.4)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -43,6 +43,9 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
     checkEvaluation(Size(Literal.create(null, MapType(StringType, StringType))), -1)
     checkEvaluation(Size(Literal.create(null, ArrayType(StringType))), -1)
+
+    checkEvaluation(Size(Literal.create(null, MapType(StringType, StringType)), 0), 0)
+    checkEvaluation(Size(Literal.create(null, ArrayType(StringType)), 0), 0)
   }
 
   test("MapKeys/MapValues") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3427,6 +3427,17 @@ object functions {
   def size(e: Column): Column = withExpr { Size(e.expr) }
 
   /**
+   * Returns length of array or map.
+   *
+   * @param e a column containing a struct or array.
+   * @param sizeOfNull - size of null input.
+   *
+   * @group collection_funcs
+   * @since 2.4.0
+   */
+  def size(e: Column, sizeOfNull: Int): Column = withExpr { Size(e.expr, sizeOfNull) }
+
+  /**
    * Sorts the input array for the given column in ascending order,
    * according to the natural ordering of the array elements.
    * Null elements will be placed at the beginning of the returned array.

--- a/sql/core/src/test/resources/sql-tests/inputs/array.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/array.sql
@@ -88,5 +88,7 @@ select
   size(double_array),
   size(float_array),
   size(date_array),
-  size(timestamp_array)
+  size(timestamp_array),
+  size(null),
+  size(null, 0)
 from primitive_arrays;

--- a/sql/core/src/test/resources/sql-tests/results/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/array.sql.out
@@ -154,9 +154,11 @@ select
   size(double_array),
   size(float_array),
   size(date_array),
-  size(timestamp_array)
+  size(timestamp_array),
+  size(null),
+  size(null, 0)
 from primitive_arrays
 -- !query 11 schema
-struct<size(boolean_array):int,size(tinyint_array):int,size(smallint_array):int,size(int_array):int,size(bigint_array):int,size(decimal_array):int,size(double_array):int,size(float_array):int,size(date_array):int,size(timestamp_array):int>
+struct<size(boolean_array):int,size(tinyint_array):int,size(smallint_array):int,size(int_array):int,size(bigint_array):int,size(decimal_array):int,size(double_array):int,size(float_array):int,size(date_array):int,size(timestamp_array):int,size(NULL):int,size(NULL):int>
 -- !query 11 output
-1	2	2	2	2	2	2	2	2	2
+1	2	2	2	2	2	2	2	2	2	-1	0

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -498,10 +498,14 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(size($"a")),
       Seq(Row(2), Row(0), Row(3), Row(-1))
     )
+    checkAnswer(df.select(size($"a", Int.MinValue)),
+      Seq(Row(2), Row(0), Row(3), Row(Int.MinValue)))
+
     checkAnswer(
       df.selectExpr("size(a)"),
       Seq(Row(2), Row(0), Row(3), Row(-1))
     )
+    checkAnswer(df.selectExpr("size(a, 0)"), Seq(Row(2), Row(0), Row(3), Row(0)))
 
     checkAnswer(
       df.selectExpr("cardinality(a)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -571,10 +571,13 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSQLContext {
       df.select(size($"a")),
       Seq(Row(2), Row(0), Row(3), Row(-1))
     )
+    checkAnswer(df.select(size($"a", 0)), Seq(Row(2), Row(0), Row(3), Row(0)))
     checkAnswer(
       df.selectExpr("size(a)"),
       Seq(Row(2), Row(0), Row(3), Row(-1))
     )
+    checkAnswer(df.selectExpr("size(a, -1)"),
+      Seq(Row(2), Row(0), Row(3), Row(-1)))
   }
 
   test("map_keys/map_values function") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the `size()` function returns `-1` for `null`s (`array` or `map` types). It restricts usage of results such as applying `sum` or `avg` for result column. In the PR, I propose to extend the `size()` function by option parameter `sizeOfNull` which allows to set size of `null`s. By default, if `sizeOfNull` is not specified, `-1` is used for backward compatibility.

## How was this patch tested?

I added SQL tests for `null` arrays - `size(null)` and `size(null, 0)`. Also added Scala and Python tests.