### PR TITLE
Rope plan append or error

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -211,16 +211,17 @@ class QueryExecution(
   }
 
   private def writePlans(append: String => Unit, maxFields: Int): Unit = {
-    def stringOrError[A](f: => A): String = {
-      try f.toString catch { case e: AnalysisException => e.toString }
-    }
     val (verbose, addSuffix) = (true, false)
 
     append("== Parsed Logical Plan ==\n")
     appendOrError(append)(logical.treeString(_, verbose, addSuffix, maxFields))
     append("\n== Analyzed Logical Plan ==\n")
-    val analyzedOutput = stringOrError(truncatedString(
-      analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", ", maxFields))
+    val analyzedOutput = try {
+      truncatedString(
+        analyzed.output.map(o => s"${o.name}: ${o.dataType.simpleString}"), ", ", maxFields)
+    } catch {
+      case e: AnalysisException => e.toString
+    }
     append(analyzedOutput)
     append("\n")
     appendOrError(append)(analyzed.treeString(_, verbose, addSuffix, maxFields))


### PR DESCRIPTION
Test `toString() exception/error handling` failed with exception:
```
org.apache.spark.sql.AnalysisException: exception;
	at org.apache.spark.sql.execution.QueryExecutionSuite$$anon$2.apply(QueryExecutionSuite.scala:137)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.$anonfun$plan$1(QueryPlanner.scala:63)
	at scala.collection.Iterator$$anon$11.nextCur(Iterator.scala:484)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:490)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:489)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.plan(QueryPlanner.scala:93)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$sparkPlan$1(QueryExecution.scala:83)
	at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
	at org.apache.spark.sql.execution.QueryExecution.sparkPlan$lzycompute(QueryExecution.scala:79)
	at org.apache.spark.sql.execution.QueryExecution.sparkPlan(QueryExecution.scala:79)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executedPlan$1(QueryExecution.scala:89)
	at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan$lzycompute(QueryExecution.scala:89)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan(QueryExecution.scala:88)
	at org.apache.spark.sql.execution.QueryExecution.org$apache$spark$sql$execution$QueryExecution$$writePlans(QueryExecution.scala:223)
	at org.apache.spark.sql.execution.QueryExecution.toString(QueryExecution.scala:229)
	at org.apache.spark.sql.execution.QueryExecutionSuite.$anonfun$new$16(QueryExecutionSuite.scala:139)
```
because the exception is not handled anymore in:
```scala
    executedPlan.appendOrError(append, verbose, addSuffix, maxFields)
```
